### PR TITLE
Make type_data public

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -223,8 +223,7 @@ pub struct Unit {
 }
 
 impl Unit {
-	/// Contains the UnitTypeData for the unit.
-	pub fn type_data(&self) -> Option<&UnitTypeData> {
+	fn type_data(&self) -> Option<&UnitTypeData> {
 		self.data.game_data.units.get(&self.type_id)
 	}
 	fn upgrades(&self) -> Reader<FxHashSet<UpgradeId>> {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -223,7 +223,8 @@ pub struct Unit {
 }
 
 impl Unit {
-	fn type_data(&self) -> Option<&UnitTypeData> {
+	/// Contains the UnitTypeData for the unit.
+	pub fn type_data(&self) -> Option<&UnitTypeData> {
 		self.data.game_data.units.get(&self.type_id)
 	}
 	fn upgrades(&self) -> Reader<FxHashSet<UpgradeId>> {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -356,6 +356,10 @@ impl Unit {
 			self.footprint_radius().map(|radius| (radius * 2.0) as usize)
 		}
 	}
+	/// How long a unit takes to build.
+	pub fn build_time(&self) -> f32{
+		self.type_data().map_or(0_f32, |data| data.build_time)
+	}
 	/// Space that unit takes in transports and bunkers.
 	pub fn cargo_size(&self) -> u32 {
 		self.type_data().map_or(0, |data| data.cargo_size)


### PR DESCRIPTION
I have certain methods that need to access fields within the UnitTypeData struct. This PR just changes the type_data function to be public