### PR TITLE
Implement From trait on Point2 for (usize, usize)

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -218,7 +218,15 @@ impl From<Point2> for (usize, usize) {
 		((p.x + 0.5) as usize, (p.y + 0.5) as usize)
 	}
 }
-
+impl From<(usize, usize)> for Point2{
+	#[inline]
+	fn from((x, y): (usize, usize)) -> Self{
+		Self{ 
+			x: x as f32 + 0.5,
+			y: y as f32 + 0.5
+		}
+	}
+}
 impl From<(f32, f32)> for Point2 {
 	#[inline]
 	fn from((x, y): (f32, f32)) -> Self {


### PR DESCRIPTION
[sc2pathlib ](https://github.com/DrInfy/sc2-pathlib) uses usize tuples to represent points on a map. I saw that there is a `From` trait for `Point2` -> `(usize, usize)`, but not the other way around.

This PR just implements the above mentioned trait