### PR TITLE
Fix supply_cap overflow

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -804,7 +804,7 @@ impl Bot {
 		self.supply_workers = common.food_workers;
 		self.supply_cap = common.food_cap;
 		self.supply_used = common.food_used;
-		self.supply_left = self.supply_cap - self.supply_used;
+		self.supply_left = self.supply_cap.saturating_sub(self.supply_used);
 
 		// Counting units and orders
 		let mut current_units = FxHashMap::default();


### PR DESCRIPTION
When spawning debug units, `self.supply_cap - self.supply-used` overflows negatively and causes an error. 
This PR changes the subtraction to use `saturating_sub` as used everywhere else where overflow might occur.