### PR TITLE
Change to_binary to use iterator

### DIFF
--- a/src/pixel_map.rs
+++ b/src/pixel_map.rs
@@ -32,14 +32,9 @@ impl<T> IndexMut<Point2> for Array2<T> {
 	}
 }
 
-fn to_binary(n: u8) -> Vec<Pixel> {
+fn to_binary(n: u8) -> impl Iterator<Item = Pixel> {
 	match n {
-		0 => vec![Pixel::Set; 8],
-		255 => vec![Pixel::Empty; 8],
-		_ => (0..8)
-			.rev()
-			.map(|x| Pixel::from_u8((n >> x) & 1).unwrap())
-			.collect(),
+		_ => (0..8).rev().map(move |x| Pixel::from_u8((n >> x) & 1).unwrap()),
 	}
 }
 

--- a/src/pixel_map.rs
+++ b/src/pixel_map.rs
@@ -33,9 +33,7 @@ impl<T> IndexMut<Point2> for Array2<T> {
 }
 
 fn to_binary(n: u8) -> impl Iterator<Item = Pixel> {
-	match n {
-		_ => (0..8).rev().map(move |x| Pixel::from_u8((n >> x) & 1).unwrap()),
-	}
+	(0..8).rev().map(move |x| Pixel::from_u8((n >> x) & 1).unwrap())
 }
 
 impl FromProto<&ImageData> for PixelMap {


### PR DESCRIPTION
This prevents allocations for each byte in the grid.