### PR TITLE
Search for maps recursively in maps dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ indexmap = "^1.5.1"
 serde = { version = "^1.0.114", features = ["derive"], optional = true }
 lazy-init = "^0.5.0"
 once_cell = "^1.8.0"
+walkdir = "^2.3.2"
 
 [dev-dependencies]
 clap = "^2.33.2"


### PR DESCRIPTION
This is useful because the headless SC2 packages for Linux come with the maps inside nested directories. Currently, you need to move each map you want to play into the root of the maps directory, this will help it work out of the box.