### PR TITLE
Fixed documentation misspelling

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -362,7 +362,7 @@ impl FromProto<&ProtoPowerSource> for PsionicMatrix {
 }
 
 /// There are different effects in SC2, some of them can harm your units,
-/// so take them into account then microing.
+/// so take them into account when microing.
 ///
 /// All effects stored in [state.observation.raw.effects](RawData::effects).
 #[derive(Clone)]


### PR DESCRIPTION
It seems that the documentation wants to convey the message that caution is needed while using certain effects.
So these effects need to be taken into consideration "when" microing the units.
"then microing" -> "when microing".