### PR TITLE
MacOS m1/m2 support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -61,7 +61,16 @@ const SC2_BINARY: &str = {
 			compile_error!("Unsupported Arch");
 		}
 	}
-	#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+	#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+	{
+		"SC2.app/Contents/MacOS/SC2"
+	}
+
+	#[cfg(not(any(
+		target_os = "windows",
+		target_os = "linux",
+		all(target_os = "macos", target_arch = "aarch64")
+	)))]
 	{
 		compile_error!("Unsupported OS");
 	}
@@ -734,6 +743,10 @@ fn launch_client(sc2_path: &str, port: i32, sc2_version: Option<&str>) -> Child 
 			}
 		}
 		#[cfg(all(target_os = "linux", not(feature = "wine_sc2")))]
+		{
+			sc2_path
+		}
+		#[cfg(target_os = "macos")]
 		{
 			sc2_path
 		}


### PR DESCRIPTION
This PR adds support for Apple Silicon-based MacOS. 
I have no idea whether directories/filenames change on the `x86_64` version (and have no way of testing it) so I constrained it to `aarch64` only.

`SC2PATH`should by default be set to `/Applications/Starcraft II`, for example with 
```rust
fn main() -> SC2Result<()> {
    #[cfg(target_os = "macos")]
    std::env::set_var("SC2PATH", "/Applications/Starcraft II");
    ...
```