### PR TITLE
calling leave() resulted in hanging bot

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -390,6 +390,7 @@ pub struct Bot {
 	pub(crate) process: Option<Child>,
 	pub(crate) api: Option<API>,
 	pub(crate) game_step: Rs<LockU32>,
+	pub(crate) game_left: bool,
 	#[doc(hidden)]
 	pub disable_fog: bool,
 	/// Actual race of your bot.
@@ -1746,10 +1747,9 @@ impl Bot {
 	///
 	/// [`on_end`]: crate::Player::on_end
 	/// [`debug.end_game`]: Debugger::end_game
-	pub fn leave(&self) -> SC2Result<()> {
-		let mut req = Request::new();
-		req.mut_leave_game();
-		self.api().send_request(req)
+	pub fn leave(&mut self) -> SC2Result<()> {
+		self.game_left = true;
+		Ok(())
 	}
 
 	pub(crate) fn close_client(&mut self) {
@@ -1779,6 +1779,7 @@ impl Default for Bot {
 	fn default() -> Self {
 		Self {
 			game_step: Rs::new(LockU32::new(1)),
+			game_left: false,
 			disable_fog: false,
 			race: Race::Random,
 			enemy_race: Race::Random,

--- a/src/client.rs
+++ b/src/client.rs
@@ -653,6 +653,12 @@ where
 		bot.on_event(e)?;
 	}
 	bot.on_step(iteration)?;
+	if bot.game_left {
+		let mut req = Request::new();
+		req.mut_leave_game();
+		bot.api().send_request(req)?;
+		return Ok(false);
+	}
 
 	let bot_actions = bot.get_actions();
 	if !bot_actions.is_empty() {


### PR DESCRIPTION
I found a small bug:
Calling `Bot::leave()` sent a leave request to SC2, but did not terminate the main loop. The next time some communication with SC2 happens, the bot waits for response and hangs.

I am not sure how good the bugfix is, but this was my best idea without changing the public interface.

I moved the `send_request` code intensionally to ensure that e.g. mutliple calls to `leave` do not result in the same problem.