### PR TITLE
derive Debug/Clone/Copy for Event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,6 +680,7 @@ impl Default for PlayerSettings<'_> {
 
 /// Events that happen in game.
 /// Passed to [`on_event`](Player::on_event).
+#[derive(Debug, Clone, Copy)]
 pub enum Event {
 	/// Unit died or structure destroyed (all units: your, enemy, neutral).
 	UnitDestroyed(u64, Option<Alliance>),


### PR DESCRIPTION
It is inconvenient to pass Event around by reference all the time, and all of the data inside Event are already copyable, so this seems like a harmless addition