### PR TITLE
Order queue fix and speedmining tweaks

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -17,7 +17,7 @@ use sc2_proto::{
 
 #[derive(Default, Clone)]
 pub(crate) struct Commander {
-	pub commands: FxHashMap<(AbilityId, Target, bool), Vec<u64>>,
+	pub commands: Vec<(AbilityId, Target, bool, Vec<u64>)>,
 	pub autocast: FxHashMap<AbilityId, Vec<u64>>,
 }
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -532,8 +532,8 @@ impl Bot {
 			actions.extend(
 				commander
 					.commands
-					.drain()
-					.map(|((ability, target, queue), units)| {
+					.drain(..)
+					.map(|(ability, target, queue, units)| {
 						Action::UnitCommand(ability, target, units, queue)
 					}),
 			);


### PR DESCRIPTION
`Commander.commands` being a hashmap causes orders to be passed to sc2 in hash order (i.e. basically random), causing queued orders to be delivered in the wrong order about 50% of the time.

This prevented implementing the key speedmining boost trick, which is to queue the `smart` command on top of the `move` command.

With this fix in place, and the speedmining boost implemented, the speedmining example increases from a 3% bonus to an 8% bonus (the same speed up that Ares achieves in the Python world).